### PR TITLE
Repeat dst MAC address 16 times according to the specification.

### DIFF
--- a/wakeonlan/wol.py
+++ b/wakeonlan/wol.py
@@ -35,7 +35,7 @@ def create_magic_packet(macaddress):
         raise ValueError('Incorrect MAC address format')
 
     # Pad the synchronization stream
-    data = b'FFFFFFFFFFFF' + (macaddress * 20).encode()
+    data = b'FFFFFFFFFFFF' + (macaddress * 16).encode()
     send_data = b''
 
     # Split up the hex values in pack


### PR DESCRIPTION
16 repetitions are enough according to the spec.

After this change a WOL packet is the same for `wol.send_magic_packet(...)` and for [WakeOnLAN software](https://wol.aquilatech.com/) in WireShark. So it's easier to reproduce some sequences in automated mode and manually.