### PR TITLE
Deprecate send_magic_packet in favor of wake

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,36 +51,36 @@ As a Python Module
 
 Import the module
 
->>> from wakeonlan import send_magic_packet
+>>> import wakeonlan
 
 
 Wake up a single computer by its mac address
 
->>> send_magic_packet('ff.ff.ff.ff.ff.ff')
+>>> wakeonlan.wake('ff.ff.ff.ff.ff.ff')
 
 Wake up a single computer by its mac address with a SecureOn password
 
->>> send_magic_packet('ff.ff.ff.ff.ff.ff/01:23:45:67:89:ab')
+>>> wakeonlan.wake('ff.ff.ff.ff.ff.ff/01:23:45:67:89:ab')
 
 Wake up multiple computers by their mac addresses.
 
->>> send_magic_packet('ff.ff.ff.ff.ff.ff',
-...                   '00-00-00-00-00-00',
-...                   'FFFFFFFFFFFF')
+>>> wakeonlan.wake('ff.ff.ff.ff.ff.ff',
+...                '00-00-00-00-00-00',
+...                'FFFFFFFFFFFF')
 
 
 An external host may be specified. Do note that port forwarding on that host is
 required. The default ip address is 255.255.255.255 and the default port is 9.
 
->>> send_magic_packet('ff.ff.ff.ff.ff.ff',
-...                   ip_address='example.com',
-...                   port=1337)
+>>> wakeonlan.wake('ff.ff.ff.ff.ff.ff',
+...                ip_address='example.com',
+...                port=1337)
 
 
 A network adapter may be specified. The magic packet will be routed through this interface.
 
->>> send_magic_packet('ff.ff.ff.ff.ff.ff',
-...                   interface='192.168.0.2')
+>>> wakeonlan.wake('ff.ff.ff.ff.ff.ff',
+...                interface='192.168.0.2')
 
 
 As a Standalone Script

--- a/poetry.lock
+++ b/poetry.lock
@@ -1109,11 +1109,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {main = "python_version < \"3.13\""}
 
 [[package]]
 name = "urllib3"
@@ -1136,4 +1137,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "b628ba98ef60516ef07f48605e73c1d1586e4a1ae438bbbce239920e79315230"
+content-hash = "26a0735843559e9d3c9fdfd801b46da16893863f6c9a8f995af0f977de1f99dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ authors = [
     { name = "Remco Haszing", email = "remcohaszing@gmail.com" }
 ]
 dynamic = ["classifiers"]
+dependencies = [
+    "typing_extensions (>=4.5.0) ; python_version < '3.13'"
+]
 
 [project.urls]
 Source = "https://github.com/remcohaszing/pywakeonlan"

--- a/test_wakeonlan.py
+++ b/test_wakeonlan.py
@@ -7,7 +7,7 @@ import socket
 import unittest
 from unittest import mock
 
-from wakeonlan import create_magic_packet, create_socket, main, send_magic_packet
+from wakeonlan import create_magic_packet, create_socket, main, wake
 
 
 class TestCreateMagicPacket(unittest.TestCase):
@@ -333,7 +333,7 @@ class TestCreateSocket(unittest.TestCase):
 
 class TestSendMagicPacket(unittest.TestCase):
     """
-    Test :func:`send_magic_packet`.
+    Test :func:`wake`.
 
     """
 
@@ -344,7 +344,7 @@ class TestSendMagicPacket(unittest.TestCase):
         """
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.bind(('127.0.0.255', 1234))
-            send_magic_packet(
+            wake(
                 '133713371337', '00-00-00-00-00-00', ip_address='127.0.0.255', port=1234
             )
             data, addr = sock.recvfrom(1024)
@@ -377,7 +377,7 @@ class TestSendMagicPacket(unittest.TestCase):
         """
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.bind(('', 1234))
-            send_magic_packet('133713371337', port=1234)
+            wake('133713371337', port=1234)
             data, addr = sock.recvfrom(1024)
             self.assertEqual(addr[0], socket.gethostbyname(socket.gethostname()))
             self.assertEqual(
@@ -408,7 +408,7 @@ class TestSendMagicPacket(unittest.TestCase):
         """
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.bind(('', 1234))
-            send_magic_packet('133713371337', '000000000000', port=1234)
+            wake('133713371337', '000000000000', port=1234)
             data = sock.recv(1024)
             self.assertEqual(
                 data,
@@ -452,14 +452,14 @@ class TestSendMagicPacket(unittest.TestCase):
                 b'\x00\x00\x00\x00\x00\x00',
             )
 
-    def test_send_magic_packet_interface(self) -> None:
+    def test_wake_interface(self) -> None:
         """
         Test whether the magic packets are broadcasted to the specified network via specified interface.
 
         """
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.bind(('<broadcast>', 1234))
-            send_magic_packet(
+            wake(
                 '133713371337',
                 interface='127.0.0.1',
                 port=1234,
@@ -494,7 +494,7 @@ class TestSendMagicPacket(unittest.TestCase):
         """
         with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
             sock.bind(('', 1234))
-            send_magic_packet(
+            wake(
                 '133713371337',
                 '00-00-00-00-00-00',
                 ip_address='::1',
@@ -530,7 +530,7 @@ class TestSendMagicPacket(unittest.TestCase):
         """
         with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
             sock.bind(('', 1234))
-            send_magic_packet(
+            wake(
                 '133713371337',
                 ip_address='localhost',
                 port=1234,
@@ -559,14 +559,14 @@ class TestSendMagicPacket(unittest.TestCase):
                 b'\x13\x37\x13\x37\x13\x37',
             )
 
-    def test_send_magic_packet_secureon(self) -> None:
+    def test_wake_secureon(self) -> None:
         """
         Test whether the magic packets are broadcasted using default values with a SecureOn password.
 
         """
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.bind(('', 1234))
-            send_magic_packet(
+            wake(
                 '01:23:45:67:89:ab/00:00:00:00:00:00',
                 port=1234,
             )
@@ -601,10 +601,10 @@ class TestMain(unittest.TestCase):
 
     """
 
-    @mock.patch('wakeonlan.send_magic_packet')
-    def test_main(self, send_magic_packet: mock.Mock) -> None:
+    @mock.patch('wakeonlan.wake')
+    def test_main(self, wake: mock.Mock) -> None:
         """
-        Test if processed arguments are passed to send_magic_packet.
+        Test if processed arguments are passed to wake.
 
         """
         main(['00:11:22:33:44:55'])
@@ -624,7 +624,7 @@ class TestMain(unittest.TestCase):
         main(['00:11:22:33:44:55', '-i', 'host.example', '-p', '1337', '-6'])
         main(['00:11:22:33:44:55', '-i', 'host.example', '-p', '1337', '-6', '-4'])
         self.assertEqual(
-            send_magic_packet.mock_calls,
+            wake.mock_calls,
             [
                 mock.call(
                     '00:11:22:33:44:55',

--- a/test_wakeonlan.py
+++ b/test_wakeonlan.py
@@ -5,9 +5,10 @@ Tests for wakeonlan.
 
 import socket
 import unittest
+import warnings
 from unittest import mock
 
-from wakeonlan import create_magic_packet, create_socket, main, wake
+from wakeonlan import create_magic_packet, create_socket, main, send_magic_packet, wake
 
 
 class TestCreateMagicPacket(unittest.TestCase):
@@ -331,7 +332,7 @@ class TestCreateSocket(unittest.TestCase):
             self.assertEqual(addr[0], '::1')
 
 
-class TestSendMagicPacket(unittest.TestCase):
+class TestWake(unittest.TestCase):
     """
     Test :func:`wake`.
 
@@ -593,6 +594,48 @@ class TestSendMagicPacket(unittest.TestCase):
                 b'\x01\x23\x45\x67\x89\xab'
                 b'\x00\x00\x00\x00\x00\x00',
             )
+
+
+class TestSendMagicPacket(unittest.TestCase):
+    """
+    Test :func:`send_magic_packet`.
+
+    """
+
+    @mock.patch('wakeonlan.wake')
+    def test_main(self, wake: mock.Mock) -> None:
+        """
+        Test if processed arguments are passed to wake.
+
+        """
+        warnings.filterwarnings('ignore')
+        send_magic_packet('00:11:22:33:44:55')
+        send_magic_packet(
+            '00:11:22:33:44:55',
+            ip_address='example.com',
+            port=1234,
+            interface='192.168.1.1',
+            address_family=socket.AF_INET,
+        )
+        self.assertEqual(
+            wake.mock_calls,
+            [
+                mock.call(
+                    '00:11:22:33:44:55',
+                    ip_address='255.255.255.255',
+                    port=9,
+                    interface=None,
+                    address_family=socket.AF_UNSPEC,
+                ),
+                mock.call(
+                    '00:11:22:33:44:55',
+                    ip_address='example.com',
+                    port=1234,
+                    interface='192.168.1.1',
+                    address_family=socket.AF_INET,
+                ),
+            ],
+        )
 
 
 class TestMain(unittest.TestCase):

--- a/wakeonlan/__init__.py
+++ b/wakeonlan/__init__.py
@@ -8,6 +8,12 @@ import argparse
 import socket
 
 
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated
+
+
 BROADCAST_IP = '255.255.255.255'
 DEFAULT_PORT = 9
 
@@ -100,7 +106,7 @@ def create_socket(
     return sock
 
 
-def send_magic_packet(
+def wake(
     *macs: str,
     ip_address: str = BROADCAST_IP,
     port: int = DEFAULT_PORT,
@@ -137,6 +143,28 @@ def send_magic_packet(
     ) as sock:
         for packet in packets:
             sock.send(packet)
+
+
+@deprecated('Use wake() instead')
+def send_magic_packet(
+    *macs: str,
+    ip_address: str = BROADCAST_IP,
+    port: int = DEFAULT_PORT,
+    interface: str | None = None,
+    address_family: socket.AddressFamily = socket.AF_UNSPEC,
+) -> None:
+    """
+    Use :func:`wake` instead.
+
+    :meta private:
+    """
+    wake(
+        *macs,
+        ip_address=ip_address,
+        port=port,
+        interface=interface,
+        address_family=address_family,
+    )
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -191,7 +219,7 @@ def main(argv: list[str] | None = None) -> None:
         address_family = socket.AF_INET
     elif args.ipv6:
         address_family = socket.AF_INET6
-    send_magic_packet(
+    wake(
         *args.macs,
         ip_address=args.ip,
         port=args.port,

--- a/wakeonlan/__init__.py
+++ b/wakeonlan/__init__.py
@@ -8,9 +8,9 @@ import argparse
 import socket
 
 
-try:
+try:  # pragma: nocover
     from warnings import deprecated
-except ImportError:
+except ImportError:  # pragma: nocover
     from typing_extensions import deprecated
 
 


### PR DESCRIPTION
The new `wake()` function will get a new call signature, but otherwise provide the same functionality.